### PR TITLE
Fix logging encoding

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -394,7 +394,7 @@ def update_display(layout, spinner_text=None):
 def get_user_selections():
     """Get all user selections before starting the analysis display."""
     # Display ASCII art welcome message
-    with open("./cli/static/welcome.txt", "r") as f:
+    with open("./cli/static/welcome.txt", "r", encoding="utf-8") as f:
         welcome_ascii = f.read()
 
     # Create welcome box content
@@ -764,7 +764,7 @@ def run_analysis():
             func(*args, **kwargs)
             timestamp, message_type, content = obj.messages[-1]
             content = content.replace("\n", " ")  # Replace newlines with spaces
-            with open(log_file, "a") as f:
+            with open(log_file, "a", encoding="utf-8", errors="ignore") as f:
                 f.write(f"{timestamp} [{message_type}] {content}\n")
         return wrapper
     
@@ -775,7 +775,7 @@ def run_analysis():
             func(*args, **kwargs)
             timestamp, tool_name, args = obj.tool_calls[-1]
             args_str = ", ".join(f"{k}={v}" for k, v in args.items())
-            with open(log_file, "a") as f:
+            with open(log_file, "a", encoding="utf-8", errors="ignore") as f:
                 f.write(f"{timestamp} [Tool Call] {tool_name}({args_str})\n")
         return wrapper
 
@@ -788,7 +788,7 @@ def run_analysis():
                 content = obj.report_sections[section_name]
                 if content:
                     file_name = f"{section_name}.md"
-                    with open(report_dir / file_name, "w") as f:
+                    with open(report_dir / file_name, "w", encoding="utf-8", errors="ignore") as f:
                         f.write(content)
         return wrapper
 

--- a/tradingagents/dataflows/finnhub_utils.py
+++ b/tradingagents/dataflows/finnhub_utils.py
@@ -25,8 +25,8 @@ def get_data_in_range(ticker, start_date, end_date, data_type, data_dir, period=
             data_dir, "finnhub_data", data_type, f"{ticker}_data_formatted.json"
         )
 
-    data = open(data_path, "r")
-    data = json.load(data)
+    with open(data_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
 
     # filter keys (date, str in format YYYY-MM-DD) by the date range (str, str in format YYYY-MM-DD)
     filtered_data = {}

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -228,6 +228,7 @@ class TradingAgentsGraph:
         with open(
             f"eval_results/{self.ticker}/TradingAgentsStrategy_logs/full_states_log_{trade_date}.json",
             "w",
+            encoding="utf-8",
         ) as f:
             json.dump(self.log_states_dict, f, indent=4)
 


### PR DESCRIPTION
## Summary
- specify utf-8 encoding when writing log and report files
- ensure reading data with utf-8 encoding
- fix graph logging with utf-8

## Testing
- `pytest -q`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_687163fd476883209110cebc5854d3be